### PR TITLE
Update: updated .csproj to net10 and updated depreciated nugget packages

### DIFF
--- a/UnitTestingExercise.Tests/UnitTestingExercise.Tests.csproj
+++ b/UnitTestingExercise.Tests/UnitTestingExercise.Tests.csproj
@@ -1,19 +1,19 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="xunit" Version="2.7.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.7">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/UnitTestingExercise.Tests/UnitTestingExercise.Tests.csproj
+++ b/UnitTestingExercise.Tests/UnitTestingExercise.Tests.csproj
@@ -8,8 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/UnitTestingExercise/UnitTestingExercise.csproj
+++ b/UnitTestingExercise/UnitTestingExercise.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates the project to use .NET 10 and upgrades several testing-related dependencies to their latest versions. These changes ensure compatibility with the latest .NET runtime and improve the reliability and features of the test suite.

Framework and dependency upgrades:

* Upgraded the target framework in both `UnitTestingExercise/UnitTestingExercise.csproj` and 
* Updated testing package dependencies in `UnitTestingExercise.Tests.csproj`:
  - `Microsoft.NET.Test.Sdk` from version 17.9.0 to 18.4.0
  - `xunit` from 2.7.0 to xunit v3 3.2.2
  - `xunit.runner.visualstudio` from 2.5.7 to 3.1.5
  - `coverlet.collector` from 6.0.1 to 10.0.0